### PR TITLE
feat: add version display supports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ $ dhttpd --help
     --host=<host>    The hostname to listen on.
                      (defaults to "localhost")
 -h, --help           Displays the help.
+    --version        Prints the version of dhttpd.
 ```
 
 [path]: https://dart.dev/tools/pub/cmd/pub-global#running-a-script-from-your-path

--- a/bin/dhttpd.dart
+++ b/bin/dhttpd.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:dhttpd/dhttpd.dart';
 import 'package:dhttpd/src/options.dart';
+import 'package:dhttpd/src/version.dart';
 
 Future<void> main(List<String> args) async {
   Options options;
@@ -16,6 +17,11 @@ Future<void> main(List<String> args) async {
 
   if (options.help) {
     print(usage);
+    return;
+  }
+
+  if (options.version) {
+    print(packageVersion);
     return;
   }
 

--- a/lib/src/options.dart
+++ b/lib/src/options.dart
@@ -31,10 +31,14 @@ class Options {
   @CliOption(abbr: 'h', negatable: false, help: 'Displays the help.')
   final bool help;
 
+  @CliOption(negatable: false, help: 'Prints the version of dhttpd.')
+  final bool version;
+
   Options({
     required this.port,
     this.path,
     required this.host,
     required this.help,
+    required this.version,
   });
 }

--- a/lib/src/options.g.dart
+++ b/lib/src/options.g.dart
@@ -25,6 +25,7 @@ Options _$parseOptionsResult(ArgResults result) => Options(
       path: result['path'] as String?,
       host: result['host'] as String,
       help: result['help'] as bool,
+      version: result['version'] as bool,
     );
 
 ArgParser _$populateOptionsParser(ArgParser parser) => parser
@@ -50,6 +51,11 @@ ArgParser _$populateOptionsParser(ArgParser parser) => parser
     'help',
     abbr: 'h',
     help: 'Displays the help.',
+    negatable: false,
+  )
+  ..addFlag(
+    'version',
+    help: 'Prints the version of dhttpd.',
     negatable: false,
   );
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,0 +1,2 @@
+// Generated code. Do not modify.
+const packageVersion = '4.0.2-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dev_dependencies:
   build_cli: ^2.0.2
   build_runner: ^2.0.0
   build_verify: '>=2.0.0 <4.0.0'
+  build_version: ^2.1.1
   lints: ^1.0.0
   path: ^1.6.1
   test: ^1.3.0

--- a/test/readme_test.dart
+++ b/test/readme_test.dart
@@ -29,6 +29,7 @@ $ dhttpd --help
     --host=<host>    The hostname to listen on.
                      (defaults to "localhost")
 -h, --help           Displays the help.
+    --version        Prints the version of dhttpd.
 ```''');
 
   expect(readme.readAsStringSync(), contains(expected));


### PR DESCRIPTION
Thanks for this little neat tool. I know there are tons of http server in other language but it is always convenient to have something we can install/upgrade using pub.

Sometimes the fastest way to check if a global pub executable is available is to run something like

```
dart pub global run dhttpd --version
```

and have an exit code of 0. I added support for the version flag. I copied what was done in webdev (using build_version) and fixed the unit tests.